### PR TITLE
Remove reference to LGPL code that doesn't actually exist

### DIFF
--- a/src/main/java/org/apache/datasketches/vector/decomposition/MatrixOps.java
+++ b/src/main/java/org/apache/datasketches/vector/decomposition/MatrixOps.java
@@ -16,39 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-//License header from the SVD.java file:
-/*
- * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- *
- * This file is part of MTJ.
- *
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation; either version 2.1 of the License, or (at your
- * option) any later version.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, write to the Free Software Foundation,
- * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
- */
-
-
 package org.apache.datasketches.vector.decomposition;
 
 import org.apache.datasketches.vector.matrix.Matrix;
 
 /**
- * Computes singular value decompositions and related Matrix operations needed by Frequent Directions.
- * May return as many singular values as exist, but other operations will limit output to k dimensions.
+ * Abstract class to wrap libraries to compute singular value
+ * decompositions and related Matrix operations needed by Frequent
+ * Directions.  May return as many singular values as exist, but other
+ * operations will limit output to k dimensions.
  */
-// Directly derived from LGPL'd Matrix Toolkit for Java (MTL):
-// https://github.com/fommil/matrix-toolkits-java/blob/master/src/main/java/no/uib/cipr/matrix/SVD.java
 abstract class MatrixOps {
 
   // iterations for SISVD


### PR DESCRIPTION
MatrixOps once used code derived from MTJ (under LGPL), but long ago was changed to an abstract class to help make any matrix library compatible. This removes outdated comments and properly describes the current class.

Since there is no  MTJ code in the library (or even support for MTJ as an external library) any reference to it is no longer relevant. The closest remnants are method names like getU(), but representing SVD of matrix A as A = U \Sigma V^t is quite common. Such a naming scheme merely keeps method names aligned with a very common mathematical representation.